### PR TITLE
syntax error in Example of pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ pipeline {
         always{
             xunit (
                 thresholds: [ skipped(failureThreshold: '0'), failed(failureThreshold: '0') ],
-                tools: [ BoostTest(pattern: 'boost/*.xml') ])
+                tools: [ BoostTest(pattern: 'boost/*.xml') ]
             )
         }
     }


### PR DESCRIPTION
syntax error: too many closing brackets, removed a closing bracket, so that example has correct syntax